### PR TITLE
Fix for mtime

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -2472,7 +2472,7 @@ class ObsidianDecentralizedSettingTab extends PluginSettingTab {
                 .setValue(this.plugin.settings.debounceDelay.toString())
                 .onChange(async (value) => {
                     const num = parseInt(value);
-                    this.plugin.settings.debounceDelay = isNaN(num) ? 1500 : num;
+                    this.plugin.settings.debounceDelay = isNaN(num) ? DEFAULT_SETTINGS.debounceDelay : num;
                     this.plugin.updateDebounceDelay();
                     await this.plugin.saveSettings();
                 }));
@@ -2484,7 +2484,7 @@ class ObsidianDecentralizedSettingTab extends PluginSettingTab {
                 .setValue(this.plugin.settings.mtimeTolerance.toString())
                 .onChange(async (value) => {
                     const num = parseInt(value);
-                    this.plugin.settings.mtimeTolerance = isNaN(num) ? 2500 : num;
+                    this.plugin.settings.mtimeTolerance = isNaN(num) ? DEFAULT_SETTINGS.mtimeTolerance : num;
                     await this.plugin.saveSettings();
                 }));
     }

--- a/main.ts
+++ b/main.ts
@@ -121,8 +121,8 @@ const DEFAULT_SETTINGS: ObsidianDecentralizedSettings = {
     hideNativeSyncStatus: false,
     maximumConcurrentTransfers: null,
     chunkSize: null,
-    debounceDelay: 1500,
-    mtimeTolerance: 2500,
+    debounceDelay: 2000,
+    mtimeTolerance: 1500,
     knownPeers: [],
 };
 
@@ -1581,9 +1581,9 @@ export default class ObsidianDecentralizedPlugin extends Plugin {
                 this.log(`Applying update (remote is newer): ${data.path}`);
                 this.ignoreNextEventForPath(data.path);
                 if (data.encoding === 'binary' || data.encoding === 'base64') {
-                    await this.app.vault.modifyBinary(existingFile, data.content as ArrayBuffer);
+                    await this.app.vault.modifyBinary(existingFile, data.content as ArrayBuffer, { mtime: data.mtime });
                 } else {
-                    await this.app.vault.modify(existingFile, data.content as string);
+                    await this.app.vault.modify(existingFile, data.content as string, { mtime: data.mtime });
                 }
                 return;
             }
@@ -1634,9 +1634,9 @@ export default class ObsidianDecentralizedPlugin extends Plugin {
                     this.log(`Conflict resolved by 'last-write-wins' (remote wins): ${data.path}`);
                     this.ignoreNextEventForPath(data.path);
                     if (data.encoding === 'binary' || data.encoding === 'base64') {
-                        await this.app.vault.modifyBinary(existingFile, data.content as ArrayBuffer);
+                        await this.app.vault.modifyBinary(existingFile, data.content as ArrayBuffer, { mtime: data.mtime });
                     } else {
-                        await this.app.vault.modify(existingFile, data.content as string);
+                        await this.app.vault.modify(existingFile, data.content as string, { mtime: data.mtime });
                     }
                 } else {
                     this.log(`Conflict resolved by 'last-write-wins' (local wins): ${data.path}`);


### PR DESCRIPTION
Discussed there: https://github.com/iWebbIO/obsidian-decentralized/issues/9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization so remote “newer” file updates apply with consistent modification timestamps, including under last-write-wins conflict resolution.

* **Chores**
  * Updated default sync timing settings (debounce delay and modification-time tolerance).
  * Enhanced Advanced Settings behavior: invalid debounce/mtime tolerance inputs now revert to the default values instead of using fixed fallback values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->